### PR TITLE
feat: es6 class should not be calling without 'new'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - 'iojs-2'
-  - '0.10'
+  - '4'
+  - '3'
+  - '2'
+  - '1'
+  - '0.12'
 script: "make test-travis"
 after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -23,7 +23,12 @@ module.exports = function inject(obj, properties, exports, target, isCall, isOve
     if (!isOverride && obj[property]) {
       throw new Error('can\'t overwrite property ' + property);
     }
-    if (isCall && is.function(exports) && !is.generatorFunction(exports)) {
+    // some restrictions:
+    // 1. should be a function
+    // 2. should not be a generator
+    // 3. should not be an es6 class (cannot be invoked without 'new')
+    // 4. isCall flag open
+    if (isCall && is.function(exports) && !is.generatorFunction(exports) && !is.class(exports)) {
       var val = exports(target);
       if (val !== undefined && val !== null) {
         obj[property] = val;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "debug": "~2.1.3",
     "globby": "~2.0.0",
-    "is-type-of": "~0.3.1"
+    "is-type-of": "~1.0.0"
   },
   "devDependencies": {
     "autod": "*",
@@ -38,7 +38,7 @@
     "loading"
   ],
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 0.12.0"
   },
   "author": "fengmk2 <fengmk2@gmail.com> (http://fengmk2.github.com)",
   "license": "MIT"

--- a/test/fixtures/babel/UserProxy.js
+++ b/test/fixtures/babel/UserProxy.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var _temporalUndefined = {};
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+var UserProxy = _temporalUndefined;
+
+function _temporalAssertDefined(val, name, undef) { if (val === undef) { throw new ReferenceError(name + ' is not defined - temporal dead zone'); } return true; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+UserProxy = (function () {
+  function UserProxy() {
+    _classCallCheck(this, _temporalAssertDefined(UserProxy, 'UserProxy', _temporalUndefined) && UserProxy);
+
+    this.user = {
+      name: 'xiaochen.gaoxc'
+    };
+  }
+
+  _createClass(_temporalAssertDefined(UserProxy, 'UserProxy', _temporalUndefined) && UserProxy, [{
+    key: 'getUser',
+    value: function getUser() {
+      return this.user;
+    }
+  }]);
+
+  return _temporalAssertDefined(UserProxy, 'UserProxy', _temporalUndefined) && UserProxy;
+})();
+
+module.exports = _temporalAssertDefined(UserProxy, 'UserProxy', _temporalUndefined) && UserProxy;

--- a/test/fixtures/class/UserProxy.js
+++ b/test/fixtures/class/UserProxy.js
@@ -1,0 +1,15 @@
+'use strict';
+
+class UserProxy {
+  constructor() {
+    this.user = {
+      name: 'xiaochen.gaoxc',
+    };
+  }
+
+  getUser() {
+    return this.user;
+  }
+}
+
+module.exports = UserProxy;

--- a/test/loading.test.js
+++ b/test/loading.test.js
@@ -92,6 +92,28 @@ describe('loading.test.js', function () {
     app.services.fooService().should.eql({a: 1});
   });
 
+  it('should loading without call es6 class', function() {
+    if (!supportEs6Class()) {
+      return;
+    }
+    var app = {};
+    loading(path.join(__dirname, 'fixtures', 'class'), {call: true})
+      .into(app, 'proxyClasses');
+    (function() {
+      app.proxyClasses.UserProxy();
+    }).should.throw('Class constructors cannot be invoked without \'new\'');
+    var instance = new app.proxyClasses.UserProxy();
+    instance.getUser().should.eql({ name: 'xiaochen.gaoxc' });
+  });
+
+  it('should loading without call babel class', function() {
+    var app = {};
+    loading(path.join(__dirname, 'fixtures', 'babel'), {call: true})
+      .into(app, 'proxyClasses');
+    var instance = new app.proxyClasses.UserProxy();
+    instance.getUser().should.eql({ name: 'xiaochen.gaoxc' });
+  });
+
   describe('into() with options.filters', function () {
     it('should only load property match the filers', function () {
       var app = {};
@@ -121,5 +143,18 @@ describe('loading.test.js', function () {
     app.services.should.have.properties('someClass', 'someDir');
     app.services.someDir.should.have.property('someSubClass');
   });
+
+  // feature detection
+  function supportEs6Class() {
+      'use strict';
+
+      if (typeof Symbol == "undefined") return false;
+      try {
+          eval("class Foo {}");
+          eval("var bar = (x) => x+1");
+      } catch (e) { return false; }
+
+      return true;
+  }
 
 });


### PR DESCRIPTION
add one restriction that es6 class should be calling directly without `new`.