### PR TITLE
Update inject.js

### DIFF
--- a/lib/inject.js
+++ b/lib/inject.js
@@ -40,5 +40,5 @@ module.exports = function inject(obj, properties, exports, target, isCall, isOve
   }
 
   obj[property] || (obj[property] = {});
-  inject(obj[property], properties, exports, target, isCall);
+  inject(obj[property], properties, exports, target, isCall, isOverride);
 };


### PR DESCRIPTION
When I load a file path with `opt={override:true}`, the error "can\'t overwrite property" would still happen.
I find the reason that the `isOverride` parameter not be passed to the call of the `inject` function recursively.
That's all.