### PR TITLE
we should pass down isOverride parameter, when we call inject function recursively.

### DIFF
--- a/lib/inject.js
+++ b/lib/inject.js
@@ -40,5 +40,5 @@ module.exports = function inject(obj, properties, exports, target, isCall, isOve
   }
 
   obj[property] || (obj[property] = {});
-  inject(obj[property], properties, exports, target, isCall);
+  inject(obj[property], properties, exports, target, isCall, isOverride);
 };

--- a/test/loading.test.js
+++ b/test/loading.test.js
@@ -74,6 +74,19 @@ describe('loading.test.js', function () {
       .into(app, 'services');
   });
 
+  it('should overwrite property from loading recursively', function () {
+    var app = {
+      services: {
+        dir: {
+          abc: true
+        }
+      }
+    };
+    loading(path.join(__dirname, 'fixtures', 'services'), { override: true })
+      .concat(path.join(__dirname, 'fixtures', 'overwrite_services'))
+      .into(app, 'services');
+  });
+
   it('should overwrite property from loading using array', function() {
     var app = {};
     loading([


### PR DESCRIPTION
When I load a file path with opt={override:true}, the error "can't overwrite property" would still happen.
I find the reason that the isOverride parameter not be passed to the call of the inject function recursively.