### PR TITLE
feat: ignore support array

### DIFF
--- a/lib/mods.js
+++ b/lib/mods.js
@@ -26,6 +26,12 @@ module.exports = function getMods(dirpath, opt) {
     files.push('!' + ignore);
   }
 
+  if (Array.isArray(ignore)) {
+    files = files.concat(ignore.map(path => {
+      return '!'+ path;
+    }));
+  }
+
   globby.sync(files, {cwd: dirpath}).forEach(function (name) {
     var fullpath = path.join(dirpath, name);
 

--- a/test/mods.test.js
+++ b/test/mods.test.js
@@ -2,6 +2,7 @@
 
 require('should');
 var join = require('path').join;
+var relative = require('path').relative;
 var getMods = require('../lib/mods');
 var fixtures = join(__dirname, 'fixtures');
 
@@ -62,6 +63,16 @@ describe('mods.test.js', function() {
     (function() {
       getMods(join(fixtures, 'error/underscore-file'));
     }).should.throw('_private is not match /^[a-z][a-z0-9_-]*$/gi in _private.js');
+  });
+
+  it('should ignore support array', function() {
+    var dir = join(fixtures, 'services');
+    var ignore = ['dir/abc.js', 'foo_service.js'];
+    var mods = getMods(dir, { ignore });
+
+    mods.every(mod => {
+      return ignore.indexOf(relative(dir, mod.fullpath)) === -1;
+    }).should.eql(true);
   });
 
 });


### PR DESCRIPTION
eg: `['a/b.js']` while load  `a/*.js`, but skip `a/b.js`