### PR TITLE
fix: remove interop-require from dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@
  */
 
 var debug = require('debug')('loading');
-var interopRequire = require('interop-require');
+var interopRequire = require('./lib/interop-require');
 var getMods = require('./lib/mods');
 var inject = require('./lib/inject');
 var is = require('is-type-of');

--- a/lib/interop-require.js
+++ b/lib/interop-require.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = function(path) {
+  var obj = require(path);
+  return isEsModule(obj) ? (hasExportDefault(obj) ? obj['default'] : obj) : obj;
+}
+
+function isEsModule(obj) {
+  return obj && obj.__esModule;
+}
+
+function defined(obj, key) {
+  return obj[key] !== undefined && obj[key] !== null;
+}
+
+function hasExportDefault(obj) {
+  return defined(obj, 'default');
+}
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "debug": "^2.2.0",
     "globby": "~2.0.0",
-    "interop-require": "^1.0.0",
     "is-type-of": "^1.0.0"
   },
   "devDependencies": {

--- a/test/fixtures/interop_require/common_export_default.js
+++ b/test/fixtures/interop_require/common_export_default.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.default = function hello() {
+  return 'world';
+}

--- a/test/fixtures/interop_require/common_no_default.js
+++ b/test/fixtures/interop_require/common_no_default.js
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.hello = function hello() {
+  return 'world';
+}
+

--- a/test/fixtures/interop_require/esmodule_default.js
+++ b/test/fixtures/interop_require/esmodule_default.js
@@ -1,0 +1,10 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+class Hello {
+    constructor() {
+    }
+    world() {
+      return 'hello world';
+    }
+}
+exports.default = Hello;

--- a/test/fixtures/interop_require/esmodule_no_default.js
+++ b/test/fixtures/interop_require/esmodule_no_default.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function hello() {
+  return 'world';
+}
+exports.hello = hello;
+;

--- a/test/interop_require.test.js
+++ b/test/interop_require.test.js
@@ -1,0 +1,45 @@
+'use strict';
+const path = require('path');
+const interopRequire = require('../lib/interop-require');
+require('should');
+
+function fixture(f) {
+  return path.join(__dirname, './fixtures/interop_require', f);
+}
+
+describe('interop_require.test.js', function() {
+
+  describe('when request esmodule with default', function() {
+    it('should return module directly', function() {
+      const esmoduleWithDefault = fixture('esmodule_default');
+      const mod = interopRequire(esmoduleWithDefault);
+      mod.name.should.equal('Hello');
+      new mod().world().should.equal('hello world');
+    });
+  });
+
+  describe('when request esmodule without default', function() {
+    it('should return origin module', function() {
+      const esmoduleWithoutDefault = fixture('esmodule_no_default');
+      const mod = interopRequire(esmoduleWithoutDefault);
+      mod.hello.name.should.equal('hello');
+      mod.hello().should.equal('world');
+    });
+  });
+
+  describe('when request common module', function() {
+    it('should return default as property', function() {
+      const commonModuleWithDefault = fixture('common_export_default');
+      const mod = interopRequire(commonModuleWithDefault);
+      mod.default.name.should.equal('hello');
+      mod.default().should.equal('world');
+    });
+
+    it('should return module', function() {
+      const commonModuleWithoutDefault = fixture('common_no_default');
+      const mod = interopRequire(commonModuleWithoutDefault);
+      mod.hello.name.should.equal('hello');
+      mod.hello().should.equal('world');
+    });
+  });
+});


### PR DESCRIPTION
remove interop-require from dependency, fix the problem when require esmodule does not export default